### PR TITLE
Eliminate global labelMap and build a labelSet for metrics in ensureLabelConsistencyForMetrics

### DIFF
--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDimensionsToCliString(t *testing.T) {
@@ -279,5 +280,34 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func Test_ensureLabelConsistencyForMetrics(t *testing.T) {
+	value1 := 1.0
+	metric1 := PrometheusMetric{
+		name:   aws.String("metric1"),
+		labels: map[string]string{"label1": "value1"},
+		value:  &value1,
+	}
+
+	value2 := 2.0
+	metric2 := PrometheusMetric{
+		name:   aws.String("metric1"),
+		labels: map[string]string{"label2": "value2"},
+		value:  &value2,
+	}
+
+	metrics := []*PrometheusMetric{&metric1, &metric2}
+	result := ensureLabelConsistencyForMetrics(metrics)
+
+	for _, metric := range result {
+		assert.Equal(t, 2, len(metric.labels))
+		labels := []string{}
+		for labelName := range metric.labels {
+			labels = append(labels, labelName)
+		}
+
+		assert.ElementsMatch(t, []string{"label1", "label2"}, labels)
 	}
 }


### PR DESCRIPTION
This should fix a data race condition we have been seeing with the package scoped labelMap. If using YACE as a library this data should be scoped per metric scrape vs globally.