### PR TITLE
Rename tagsData, tagsSemaphore, cloudwatchSemaphore, and migrateTagsToPrometheus

### DIFF
--- a/pkg/abstract.go
+++ b/pkg/abstract.go
@@ -28,7 +28,6 @@ func scrapeAwsData(config ScrapeConf, now time.Time, metricsPerQuery int, fips, 
 					result, err := clientSts.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 					if err != nil {
 						log.Printf("Couldn't get account Id for role %s: %s\n", role.RoleArn, err.Error())
-						return
 					}
 					accountId := result.Account
 
@@ -66,7 +65,6 @@ func scrapeAwsData(config ScrapeConf, now time.Time, metricsPerQuery int, fips, 
 					result, err := clientSts.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 					if err != nil {
 						log.Printf("Couldn't get account Id for role %s: %s\n", role.RoleArn, err.Error())
-						return
 					}
 					accountId := result.Account
 

--- a/pkg/abstract_test.go
+++ b/pkg/abstract_test.go
@@ -9,11 +9,11 @@ func TestFilterThroughTags(t *testing.T) {
 
 	// Arrange
 	expected := true
-	tagsData := tagsData{}
+	resource := resource{}
 	filterTags := []Tag{}
 
 	// Act
-	actual := tagsData.filterThroughTags(filterTags)
+	actual := resource.filterThroughTags(filterTags)
 
 	// Assert
 	if actual != expected {

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -298,8 +298,8 @@ func getFullMetricsList(namespace string, metric *Metric, clientCloudwatch cloud
 	return &res, nil
 }
 
-func getFilteredMetricDatas(region string, accountId *string, namespace string, customTags []Tag, tagsOnMetrics exportedTagsOnMetrics, dimensionRegexps []*string, resources []*tagsData, metricsList []*cloudwatch.Metric, m *Metric) (getMetricsData []cloudwatchData) {
-	type filterValues map[string]*tagsData
+func getFilteredMetricDatas(region string, accountId *string, namespace string, customTags []Tag, tagsOnMetrics exportedTagsOnMetrics, dimensionRegexps []*string, resources []*resource, metricsList []*cloudwatch.Metric, m *Metric) (getMetricsData []cloudwatchData) {
+	type filterValues map[string]*resource
 	dimensionsFilter := make(map[string]filterValues)
 	for _, dr := range dimensionRegexps {
 		dimensionRegexp := regexp.MustCompile(*dr)
@@ -325,7 +325,7 @@ func getFilteredMetricDatas(region string, accountId *string, namespace string, 
 	}
 	for _, cwMetric := range metricsList {
 		skip := false
-		r := &tagsData{
+		r := &resource{
 			ID:        aws.String("global"),
 			Namespace: &namespace,
 		}
@@ -386,10 +386,11 @@ func createPrometheusLabels(cwd *cloudwatchData, labelsSnakeCase bool) map[strin
 }
 
 func ensureLabelConsistencyForMetrics(metrics []*PrometheusMetric) []*PrometheusMetric {
-	labelSetForMetric := make(map[string]map[string]bool, len(metrics))
+	type metricLabels map[string]bool
+	labelSetForMetric := make(map[string]metricLabels, 0)
 	for _, metric := range metrics {
 		if _, ok := labelSetForMetric[*metric.name]; !ok {
-			labelSetForMetric[*metric.name] = make(map[string]bool)
+			labelSetForMetric[*metric.name] = make(metricLabels)
 		}
 
 		for label := range metric.labels {

--- a/pkg/aws_cloudwatch.go
+++ b/pkg/aws_cloudwatch.go
@@ -385,8 +385,12 @@ func createPrometheusLabels(cwd *cloudwatchData, labelsSnakeCase bool) map[strin
 	return labels
 }
 
+type metricLabels map[string]bool
+
+// ensureLabelConsistencyForMetrics accumulates all labels from the incoming metrics and adds
+// all known labels to metrics. Prometheus requires that all metrics with the same name
+// have the same set of labels
 func ensureLabelConsistencyForMetrics(metrics []*PrometheusMetric) []*PrometheusMetric {
-	type metricLabels map[string]bool
 	labelSetForMetric := make(map[string]metricLabels, 0)
 	for _, metric := range metrics {
 		if _, ok := labelSetForMetric[*metric.name]; !ok {

--- a/pkg/aws_cloudwatch_test.go
+++ b/pkg/aws_cloudwatch_test.go
@@ -66,7 +66,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 		customTags       []Tag
 		tagsOnMetrics    exportedTagsOnMetrics
 		dimensionRegexps []*string
-		resources        []*tagsData
+		resources        []*resource
 		metricsList      []*cloudwatch.Metric
 		m                *Metric
 	}
@@ -89,7 +89,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					},
 				},
 				dimensionRegexps: SupportedServices.GetService("ec2").DimensionRegexps,
-				resources: []*tagsData{
+				resources: []*resource{
 					{
 						ID: aws.String("arn:aws:ec2:us-east-1:123123123123:instance/i-12312312312312312"),
 						Tags: []*Tag{
@@ -172,7 +172,7 @@ func Test_getFilteredMetricDatas(t *testing.T) {
 					},
 				},
 				dimensionRegexps: SupportedServices.GetService("kafka").DimensionRegexps,
-				resources: []*tagsData{
+				resources: []*resource{
 					{
 						ID: aws.String("arn:aws:kafka:us-east-1:123123123123:cluster/demo-cluster-1/12312312-1231-1231-1231-123123123123-12"),
 						Tags: []*Tag{

--- a/pkg/aws_tags.go
+++ b/pkg/aws_tags.go
@@ -19,6 +19,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// Represents an AWS resource returned by the AWS GetResourcesPages API
 type resource struct {
 	ID        *string
 	Tags      []*Tag
@@ -149,6 +150,8 @@ func (iface tagsInterface) get(job *Job, region string) (resources []*resource, 
 	return resources, err
 }
 
+// generateAWSInfoMetrics transforms the provided resources in to prometheus compatible metrics of the form
+// aws_"namespace"_info with all tags from the resource added as labels
 func generateAWSInfoMetrics(resources []*resource, labelsSnakeCase bool) []*PrometheusMetric {
 	output := make([]*PrometheusMetric, 0)
 	tagList := make(map[string][]string)

--- a/pkg/aws_tags_test.go
+++ b/pkg/aws_tags_test.go
@@ -11,8 +11,8 @@ func TestMigrateTagsToPrometheus(t *testing.T) {
 	region := "us-east-1"
 	tagItem := Tag{Key: "Name", Value: "tag_Value"}
 	tags := []*Tag{&tagItem}
-	tagData := tagsData{ID: &id, Namespace: &namespace, Region: &region, Tags: tags}
-	tagsData := []*tagsData{&tagData}
+	r := resource{ID: &id, Namespace: &namespace, Region: &region, Tags: tags}
+	resources := []*resource{&r}
 
 	// Arrange
 	prometheusMetricName := "aws_service_info"
@@ -29,7 +29,7 @@ func TestMigrateTagsToPrometheus(t *testing.T) {
 	expected := []*PrometheusMetric{&p}
 
 	// Act
-	actual := migrateTagsToPrometheus(tagsData, false)
+	actual := generateAWSInfoMetrics(resources, false)
 
 	// Assert
 	if *actual[0].name != *expected[0].name {


### PR DESCRIPTION
The names for these are a bit misleading so I've renamed them to hopefully match their usage a bit better,

tagsData -> resource: a lot of the variable names are already resource and a resource has Tags
tagsSemaphore -> discoveryJobSemaphore: this channel is used by two different Cloudwatch API calls in the discovery job code path
cloudwatchSemaphore -> staticJobSemaphore: this one is only used around calling CloudWatch in the static job so it's name is really misleading because there are a fair amount of other CloudWatch calls which don't respect this
migrateTagsToPrometheus -> generateAWSInfoMetrics: This uses the data from resources to generate the `aws_x_info` metrics which get exported